### PR TITLE
added signingRequired parameter

### DIFF
--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbEndpoint.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbEndpoint.java
@@ -33,6 +33,9 @@ public class SmbEndpoint extends GenericFileEndpoint<SmbFile> {
     @UriParam
     protected boolean dfs;
 
+    @UriParam
+    protected boolean signingRequired;
+
     public SmbEndpoint(String uri, SmbComponent smbComponent, SmbConfiguration configuration) {
         super(uri, smbComponent);
         this.configuration = configuration;
@@ -87,6 +90,14 @@ public class SmbEndpoint extends GenericFileEndpoint<SmbFile> {
         this.dfs = dfsEnabled;
     }
 
+    public boolean isSigningRequired() {
+        return signingRequired;
+    }
+
+    public void setSigningRequired(boolean signingRequired) {
+        this.signingRequired = signingRequired;
+    }
+
     @Override
     public Exchange createExchange(GenericFile<SmbFile> file) {
         Exchange answer = new DefaultExchange(this);
@@ -108,6 +119,7 @@ public class SmbEndpoint extends GenericFileEndpoint<SmbFile> {
                     .builder()
                     .withMultiProtocolNegotiate(true)
                     .withDfsEnabled(isDfs())
+                    .withSigningRequired(isSigningRequired())
                     .build();
     }
 

--- a/src/test/groovy/com/github/jborza/camel/component/smbj/SmbEndpointSpec.groovy
+++ b/src/test/groovy/com/github/jborza/camel/component/smbj/SmbEndpointSpec.groovy
@@ -55,12 +55,28 @@ class SmbEndpointSpec extends Specification {
         def component = Mock(SmbComponent)
         def config = new SmbConfiguration(new URI(uri))
         def endpoint = new SmbEndpoint(uri, component, config)
+
         //Camel usually sets this from URL
         endpoint.setDfs(expectedDfs)
         endpoint.isDfs() == expectedDfs
 
         where:
         expectedDfs << [true, false]
+    }
+
+    def "signingRequired attribute is set up"() {
+        expect:
+        def uri = "smb2://server/share?signingRequired=true"
+        def component = Mock(SmbComponent)
+        def config = new SmbConfiguration(new URI(uri))
+        def endpoint = new SmbEndpoint(uri, component, config)
+
+        //Camel usually sets this from URL
+        endpoint.setSigningRequired(expectedSigningRequired)
+        endpoint.isSigningRequired() == expectedSigningRequired
+
+        where:
+        expectedSigningRequired << [true, false]
     }
 
     def "createProducer returns SmbProducer"() {


### PR DESCRIPTION
It seems it is sometimes necessary to set withSigningRequired(true) to have the smbj working correctly with DFS.