### PR TITLE
Camel smbshare connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 target/
+
+.idea
+*.iws
+*.iml
+*.ipr

--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,10 @@ limitations under the License.
 
     <properties>
         <cobertura.version>2.7</cobertura.version>
-        <camel.version>2.22.1</camel.version>
-        <smbj.version>0.9.0</smbj.version>
+        <camel.version>2.19.3</camel.version>
+        <smbj.version>0.10.0</smbj.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <slf4j-api.version>1.7.25</slf4j-api.version>
+        <slf4j-api.version>1.7.22</slf4j-api.version>
         <cglib.version>3.2.6</cglib.version>
         <objenesis.version>2.6</objenesis.version>
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
@@ -56,7 +56,7 @@ limitations under the License.
         <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
-        <commons-io.version>2.5</commons-io.version>
+        <commons-io.version>2.4</commons-io.version>
     </properties>
 
     <scm>

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbConsumer.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbConsumer.java
@@ -30,8 +30,8 @@ public class SmbConsumer extends GenericFileConsumer<SmbFile> {
     private final String currentRelativePath = "";
     private GenericFileConverter genericFileConverter;
 
-    public SmbConsumer(GenericFileEndpoint<SmbFile> endpoint, Processor processor, GenericFileOperations<SmbFile> operations, GenericFileProcessStrategy<SmbFile> processStrategy) {
-        super(endpoint, processor, operations, processStrategy);
+    public SmbConsumer(GenericFileEndpoint<SmbFile> endpoint, Processor processor, GenericFileOperations<SmbFile> operations) {
+        super(endpoint, processor, operations);
         SmbConfiguration config = (SmbConfiguration) endpoint.getConfiguration();
         this.endpointPath = config.getShare() + "\\" + config.getPath();
         genericFileConverter = new GenericFileConverter();
@@ -123,5 +123,10 @@ public class SmbConsumer extends GenericFileConsumer<SmbFile> {
                 startScheduler();
             }
         }
+    }
+
+    @Override
+    protected boolean isRetrieveFile(){
+        return ((SmbEndpoint)getEndpoint()).isDownload();
     }
 }

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbEndpoint.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbEndpoint.java
@@ -30,6 +30,8 @@ import org.apache.camel.spi.UriParam;
 @UriEndpoint(scheme = "smb2", title = "SMBJ", syntax = "smb2://user@server.example.com/sharename?password=secret&localWorkDirectory=/tmp", consumerClass = SmbConsumer.class)
 public class SmbEndpoint extends GenericFileEndpoint<SmbFile> {
 
+    private boolean download = true;
+
     @UriParam
     protected boolean dfs;
 
@@ -46,7 +48,7 @@ public class SmbEndpoint extends GenericFileEndpoint<SmbFile> {
     @Override
     public SmbConsumer createConsumer(Processor processor) throws Exception {
         createProcessStrategyIfNotSet();
-        SmbConsumer consumer = new SmbConsumer(this, processor, createSmbOperations(), getProcessStrategy());
+        SmbConsumer consumer = new SmbConsumer(this, processor, createSmbOperations());
         if (isDelete() && getMove() != null) {
             throw new IllegalArgumentException("You cannot set both delete=true and move options");
         }
@@ -129,5 +131,13 @@ public class SmbEndpoint extends GenericFileEndpoint<SmbFile> {
     @Override
     public boolean isSingleton() {
         return false;
+    }
+
+    public boolean isDownload(){
+        return download;
+    }
+
+    public void setDownload(boolean download){
+        this.download = download;
     }
 }

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbOperations.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbOperations.java
@@ -92,7 +92,7 @@ public class SmbOperations implements GenericFileOperations<SmbFile>, SmbShareFa
 
     @Override
     @SuppressWarnings("unused")
-    public boolean retrieveFile(String name, Exchange exchange, long size) throws GenericFileOperationFailedException {
+    public boolean retrieveFile(String name, Exchange exchange) throws GenericFileOperationFailedException {
         if (ObjectHelper.isNotEmpty(endpoint.getLocalWorkDirectory())) {
             // local work directory is configured so we should store file content as files in this local directory
             return retrieveFileToFileInLocalWorkDirectory(name, exchange);
@@ -103,7 +103,7 @@ public class SmbOperations implements GenericFileOperations<SmbFile>, SmbShareFa
     }
 
     @Override
-    public void releaseRetrievedFileResources(Exchange exchange) throws GenericFileOperationFailedException {
+    public void releaseRetreivedFileResources(Exchange exchange) throws GenericFileOperationFailedException {
         //intentionally left blank
     }
 
@@ -239,7 +239,7 @@ public class SmbOperations implements GenericFileOperations<SmbFile>, SmbShareFa
     }
 
     @Override
-    public boolean storeFile(String name, Exchange exchange, long size) {
+    public boolean storeFile(String name, Exchange exchange) {
         if (shouldCheckForFileExists() && existsFile(name)) {
             if (endpoint.getFileExist() == GenericFileExist.Override && endpoint.isEagerDeleteTargetFile()) {
                 log.debug("Eagerly deleting existing file: {}", name);

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbProducer.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbProducer.java
@@ -46,7 +46,7 @@ public class SmbProducer extends GenericFileProducer<SmbFile> {
             log.debug("About to write [" + fileName + "] to [" + getEndpoint() + "] from exchange [" + exchange + "]");
         }
         final int SIZE_UNKNOWN = 0;
-        operations.storeFile(fileNameWithoutShare, exchange, SIZE_UNKNOWN);
+        operations.storeFile(fileNameWithoutShare, exchange);
 
         if (log.isDebugEnabled()) {
             log.debug("Wrote [" + fileName + "] to [" + getEndpoint() + "]");

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbShare.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbShare.java
@@ -105,6 +105,11 @@ public class SmbShare implements AutoCloseable {
         return share;
     }
 
+    public DiskShare connectAndGetShare(String path){
+        connect(path);
+        return getShare();
+    }
+
     /**
      * @return The DFS resolved path, if DFS is used. Otherwise the supplied path is returned
      */

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbShare.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbShare.java
@@ -203,7 +203,7 @@ public class SmbShare implements AutoCloseable {
         try (File file = openForWrite(getShare(), getPath());
              OutputStream outputStream = file.getOutputStream()
         ) {
-            IOUtils.copy(inputStream, outputStream, bufferSize);
+            IOUtils.copy(inputStream, outputStream);
         }
     }
 


### PR DESCRIPTION
Updated smb share to be able to get the connected share. As I've seen getshare method returns the connected share but visibility of connect method does not allow us to connect without doing any other operation. So connectAndGet will help to do that.