### PR TITLE
Smb producer is not compatible with camel 3.8.0 #27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 target/
+.idea
+camel-smbj.iml

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ limitations under the License.
 
     <properties>
         <cobertura.version>2.7</cobertura.version>
-        <camel.version>2.22.1</camel.version>
+        <camel.version>3.11.1</camel.version>
         <smbj.version>0.9.0</smbj.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j-api.version>1.7.25</slf4j-api.version>
@@ -79,11 +79,55 @@ limitations under the License.
             <artifactId>camel-core</artifactId>
             <version>${camel.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-file</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-api</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-util</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-support</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
 
         <!-- camel for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test</artifactId>
+            <version>${camel.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-main</artifactId>
+            <version>${camel.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-model</artifactId>
+            <version>${camel.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-engine</artifactId>
+            <version>${camel.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-base-engine</artifactId>
             <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,9 @@ Where share represents the share to connect to and dir is optionally any underly
 You can append query options to the URI in the following format, ?option=value&option=value&...
 This component uses the [SMBJ library](https://github.com/hierynomus/smbj) for the actual SMB work.
 
+One of the possible options is  "password" option for which you can use RAW() in case your password contains some exotic
+non-encodeable chars. 
+
 
 By itself, the camel-smbj component is an extension of the [File component](http://camel.apache.org/file2.html).
 

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbConfiguration.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbConfiguration.java
@@ -25,10 +25,6 @@ public class SmbConfiguration extends GenericFileConfiguration {
 
     private static final String DOMAIN_SEPARATOR = ";";
     private static final String USER_PASS_SEPARATOR = ":";
-    private static final String PASSWORD_PARAM_NAME = "password";
-
-
-    private final static String RAW_BEGIN = "RAW(";
     private String domain;
     private String username;
     private String password;

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbConfiguration.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbConfiguration.java
@@ -17,15 +17,24 @@
 package com.github.jborza.camel.component.smbj;
 
 import org.apache.camel.component.file.GenericFileConfiguration;
+import org.apache.camel.util.Pair;
 import org.apache.camel.util.StringHelper;
+import org.apache.camel.util.URISupport;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class SmbConfiguration extends GenericFileConfiguration {
 
     private static final String DOMAIN_SEPARATOR = ";";
     private static final String USER_PASS_SEPARATOR = ":";
+    private static final String PASSWORD_PARAM_NAME = "password";
 
+
+    private final static String RAW_BEGIN = "RAW(";
     private String domain;
     private String username;
     private String password;
@@ -41,6 +50,23 @@ public class SmbConfiguration extends GenericFileConfiguration {
 
     @Override
     public void configure(URI uri) {
+        Optional<String> parametricPassword = Optional.empty();
+        Map<String, Object> parameters = Collections.emptyMap();
+        try {
+            parameters = URISupport.parseParameters(uri);
+        } catch (Exception e){
+            throw new RuntimeException(e);
+        }
+        if (parameters.containsKey(PASSWORD_PARAM_NAME)){
+            List<Pair<Integer>> passwordParamRaw = URISupport.scanRaw(parameters.get(PASSWORD_PARAM_NAME)
+                                                                     .toString());
+            if (passwordParamRaw.size() > 0){
+                parametricPassword = Optional.of(parameters.get(PASSWORD_PARAM_NAME).toString().substring(passwordParamRaw.get(0).getLeft()+RAW_BEGIN.length(), passwordParamRaw.get(0).getRight()));
+            }
+            else {
+                parametricPassword = Optional.of(parameters.get(PASSWORD_PARAM_NAME).toString());
+            }
+        }
         super.configure(uri);
         String userInfo = uri.getUserInfo();
 
@@ -56,7 +82,9 @@ public class SmbConfiguration extends GenericFileConfiguration {
                 setUsername(userInfo);
             }
         }
-
+        if (parametricPassword.isPresent()) {
+            setPassword(parametricPassword.get());
+        }
         setHost(uri.getHost());
         setPort(uri.getPort());
         setPath(uri.getPath());

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbConfiguration.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbConfiguration.java
@@ -17,15 +17,9 @@
 package com.github.jborza.camel.component.smbj;
 
 import org.apache.camel.component.file.GenericFileConfiguration;
-import org.apache.camel.util.Pair;
 import org.apache.camel.util.StringHelper;
-import org.apache.camel.util.URISupport;
 
 import java.net.URI;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 public class SmbConfiguration extends GenericFileConfiguration {
 
@@ -50,23 +44,6 @@ public class SmbConfiguration extends GenericFileConfiguration {
 
     @Override
     public void configure(URI uri) {
-        Optional<String> parametricPassword = Optional.empty();
-        Map<String, Object> parameters = Collections.emptyMap();
-        try {
-            parameters = URISupport.parseParameters(uri);
-        } catch (Exception e){
-            throw new RuntimeException(e);
-        }
-        if (parameters.containsKey(PASSWORD_PARAM_NAME)){
-            List<Pair<Integer>> passwordParamRaw = URISupport.scanRaw(parameters.get(PASSWORD_PARAM_NAME)
-                                                                     .toString());
-            if (passwordParamRaw.size() > 0){
-                parametricPassword = Optional.of(parameters.get(PASSWORD_PARAM_NAME).toString().substring(passwordParamRaw.get(0).getLeft()+RAW_BEGIN.length(), passwordParamRaw.get(0).getRight()));
-            }
-            else {
-                parametricPassword = Optional.of(parameters.get(PASSWORD_PARAM_NAME).toString());
-            }
-        }
         super.configure(uri);
         String userInfo = uri.getUserInfo();
 
@@ -81,9 +58,6 @@ public class SmbConfiguration extends GenericFileConfiguration {
             } else {
                 setUsername(userInfo);
             }
-        }
-        if (parametricPassword.isPresent()) {
-            setPassword(parametricPassword.get());
         }
         setHost(uri.getHost());
         setPort(uri.getPort());

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbConsumer.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbConsumer.java
@@ -19,12 +19,21 @@ package com.github.jborza.camel.component.smbj;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
-import org.apache.camel.component.file.*;
+import org.apache.camel.component.file.GenericFile;
+import org.apache.camel.component.file.GenericFileConsumer;
+import org.apache.camel.component.file.GenericFileEndpoint;
+import org.apache.camel.component.file.GenericFileOperationFailedException;
+import org.apache.camel.component.file.GenericFileOperations;
+import org.apache.camel.component.file.GenericFileProcessStrategy;
 import org.apache.camel.util.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class SmbConsumer extends GenericFileConsumer<SmbFile> {
+
+    private Logger log = LoggerFactory.getLogger(this.getClass());
 
     private final String endpointPath;
     private final String currentRelativePath = "";
@@ -35,6 +44,16 @@ public class SmbConsumer extends GenericFileConsumer<SmbFile> {
         SmbConfiguration config = (SmbConfiguration) endpoint.getConfiguration();
         this.endpointPath = config.getShare() + "\\" + config.getPath();
         genericFileConverter = new GenericFileConverter();
+    }
+
+    @Override
+    protected Exchange createExchange(GenericFile<SmbFile> file) {
+        Exchange exchange = this.createExchange(true);
+        if (file != null) {
+            file.bindToExchange(exchange);
+        }
+
+        return exchange;
     }
 
     @Override

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbEndpoint.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbEndpoint.java
@@ -16,6 +16,7 @@
 
 package com.github.jborza.camel.component.smbj;
 
+import com.hierynomus.smbj.SmbConfig;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.file.GenericFile;
@@ -28,10 +29,6 @@ import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.hierynomus.smbj.SmbConfig;
-
-import java.util.concurrent.ConcurrentHashMap;
 
 @UriEndpoint(scheme = "smb2", title = "SMBJ", syntax = "smb2://user@server.example.com/sharename?password=secret&localWorkDirectory=/tmp", consumerClass = SmbConsumer.class)
 public class SmbEndpoint extends GenericFileEndpoint<SmbFile> {
@@ -117,16 +114,6 @@ public class SmbEndpoint extends GenericFileEndpoint<SmbFile> {
             file.bindToExchange(answer);
         }
         return answer;
-    }
-
-    @Override
-    public Exchange createExchange() {
-        Exchange exchange = super.createExchange();
-        if (exchange.getProperties() == null && DefaultExchange.class.isAssignableFrom(exchange.getClass())){
-            DefaultExchange def = (DefaultExchange) exchange;
-            def.setProperties(new ConcurrentHashMap<>());
-        }
-        return exchange;
     }
 
     public SmbOperations createSmbOperations() {

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbFileProcessStrategy.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbFileProcessStrategy.java
@@ -1,0 +1,270 @@
+package com.github.jborza.camel.component.smbj;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Expression;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.component.file.GenericFileExclusiveReadLockStrategy;
+import org.apache.camel.component.file.GenericFileProcessStrategy;
+import org.apache.camel.component.file.GenericFileProcessStrategyFactory;
+import org.apache.camel.component.file.strategy.FileChangedExclusiveReadLockStrategy;
+import org.apache.camel.component.file.strategy.FileIdempotentChangedRepositoryReadLockStrategy;
+import org.apache.camel.component.file.strategy.FileIdempotentRenameRepositoryReadLockStrategy;
+import org.apache.camel.component.file.strategy.FileIdempotentRepositoryReadLockStrategy;
+import org.apache.camel.component.file.strategy.FileLockExclusiveReadLockStrategy;
+import org.apache.camel.component.file.strategy.FileRenameExclusiveReadLockStrategy;
+import org.apache.camel.component.file.strategy.GenericFileDeleteProcessStrategy;
+import org.apache.camel.component.file.strategy.GenericFileExpressionRenamer;
+import org.apache.camel.component.file.strategy.GenericFileRenameProcessStrategy;
+import org.apache.camel.component.file.strategy.MarkerFileExclusiveReadLockStrategy;
+import org.apache.camel.spi.IdempotentRepository;
+import org.apache.camel.spi.Language;
+import org.apache.camel.util.ObjectHelper;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class SmbFileProcessStrategy implements GenericFileProcessStrategyFactory<SmbFile> {
+
+    public GenericFileProcessStrategy<SmbFile> createGenericFileProcessStrategy(CamelContext context, Map<String, Object> params) {
+        Expression moveExpression = (Expression)params.get("move");
+        Expression moveFailedExpression = (Expression)params.get("moveFailed");
+        Expression preMoveExpression = (Expression)params.get("preMove");
+        boolean isNoop = params.get("noop") != null;
+        boolean isDelete = params.get("delete") != null;
+        boolean isMove = moveExpression != null || preMoveExpression != null || moveFailedExpression != null;
+        GenericFileExpressionRenamer renamer;
+        if (isDelete) {
+            GenericFileDeleteProcessStrategy<SmbFile> strategy = new GenericFileDeleteProcessStrategy();
+            strategy.setExclusiveReadLockStrategy(getExclusiveReadLockStrategy(params));
+            if (preMoveExpression != null) {
+                renamer = new GenericFileExpressionRenamer();
+                renamer.setExpression(preMoveExpression);
+                strategy.setBeginRenamer(renamer);
+            }
+
+            if (moveFailedExpression != null) {
+                renamer = new GenericFileExpressionRenamer();
+                renamer.setExpression(moveFailedExpression);
+                strategy.setFailureRenamer(renamer);
+            }
+
+            return strategy;
+        } else {
+            GenericFileRenameProcessStrategy strategy;
+            if (!isMove && !isNoop) {
+                strategy = new GenericFileRenameProcessStrategy();
+                strategy.setExclusiveReadLockStrategy(getExclusiveReadLockStrategy(params));
+                strategy.setCommitRenamer(getDefaultCommitRenamer(context));
+                return strategy;
+            } else {
+                strategy = new GenericFileRenameProcessStrategy();
+                strategy.setExclusiveReadLockStrategy(getExclusiveReadLockStrategy(params));
+                if (!isNoop) {
+                    if (moveExpression != null) {
+                        renamer = new GenericFileExpressionRenamer();
+                        renamer.setExpression(moveExpression);
+                        strategy.setCommitRenamer(renamer);
+                    } else {
+                        strategy.setCommitRenamer(getDefaultCommitRenamer(context));
+                    }
+                }
+
+                if (preMoveExpression != null) {
+                    renamer = new GenericFileExpressionRenamer();
+                    renamer.setExpression(preMoveExpression);
+                    strategy.setBeginRenamer(renamer);
+                }
+
+                if (moveFailedExpression != null) {
+                    renamer = new GenericFileExpressionRenamer();
+                    renamer.setExpression(moveFailedExpression);
+                    strategy.setFailureRenamer(renamer);
+                }
+
+                return strategy;
+            }
+        }
+    }
+
+    private static GenericFileExpressionRenamer<File> getDefaultCommitRenamer(CamelContext context) {
+        Language language = context.resolveLanguage("file");
+        Expression expression = language.createExpression("${file:parent}/.camel/${file:onlyname}");
+        return new GenericFileExpressionRenamer(expression);
+    }
+
+    private static GenericFileExclusiveReadLockStrategy<SmbFile> getExclusiveReadLockStrategy(Map<String, Object> params) {
+        GenericFileExclusiveReadLockStrategy<File> strategy = (GenericFileExclusiveReadLockStrategy)params.get("exclusiveReadLockStrategy");
+        if (strategy != null) {
+            return (GenericFileExclusiveReadLockStrategy)strategy;
+        } else {
+            String readLock = (String)params.get("readLock");
+            if (ObjectHelper.isNotEmpty(readLock)) {
+                if ("none".equals(readLock) || "false".equals(readLock)) {
+                    return null;
+                }
+
+                Long minLength;
+                if ("markerFile".equals(readLock)) {
+                    strategy = new MarkerFileExclusiveReadLockStrategy();
+                } else if ("fileLock".equals(readLock)) {
+                    strategy = new FileLockExclusiveReadLockStrategy();
+                } else if ("rename".equals(readLock)) {
+                    strategy = new FileRenameExclusiveReadLockStrategy();
+                } else if ("changed".equals(readLock)) {
+                    FileChangedExclusiveReadLockStrategy readLockStrategy = new FileChangedExclusiveReadLockStrategy();
+                    minLength = (Long)params.get("readLockMinLength");
+                    if (minLength != null) {
+                        readLockStrategy.setMinLength(minLength);
+                    }
+
+                    Long minAge = (Long)params.get("readLockMinAge");
+                    if (null != minAge) {
+                        readLockStrategy.setMinAge(minAge);
+                    }
+
+                    strategy = readLockStrategy;
+                } else {
+                    IdempotentRepository repo;
+                    Integer readLockIdempotentReleaseDelay;
+                    Boolean readLockRemoveOnRollback;
+                    Boolean readLockRemoveOnCommit;
+                    if ("idempotent".equals(readLock)) {
+                        FileIdempotentRepositoryReadLockStrategy readLockStrategy = new FileIdempotentRepositoryReadLockStrategy();
+                        readLockRemoveOnRollback = (Boolean)params.get("readLockRemoveOnRollback");
+                        if (readLockRemoveOnRollback != null) {
+                            readLockStrategy.setRemoveOnRollback(readLockRemoveOnRollback);
+                        }
+
+                        readLockRemoveOnCommit = (Boolean)params.get("readLockRemoveOnCommit");
+                        if (readLockRemoveOnCommit != null) {
+                            readLockStrategy.setRemoveOnCommit(readLockRemoveOnCommit);
+                        }
+
+                        repo = (IdempotentRepository)params.get("readLockIdempotentRepository");
+                        if (repo != null) {
+                            readLockStrategy.setIdempotentRepository(repo);
+                        }
+
+                        readLockIdempotentReleaseDelay = (Integer)params.get("readLockIdempotentReleaseDelay");
+                        if (readLockIdempotentReleaseDelay != null) {
+                            readLockStrategy.setReadLockIdempotentReleaseDelay(readLockIdempotentReleaseDelay);
+                        }
+
+                        Boolean readLockIdempotentReleaseAsync = (Boolean)params.get("readLockIdempotentReleaseAsync");
+                        if (readLockIdempotentReleaseAsync != null) {
+                            readLockStrategy.setReadLockIdempotentReleaseAsync(readLockIdempotentReleaseAsync);
+                        }
+
+                        readLockIdempotentReleaseDelay = (Integer)params.get("readLockIdempotentReleaseAsyncPoolSize");
+                        if (readLockIdempotentReleaseDelay != null) {
+                            readLockStrategy.setReadLockIdempotentReleaseAsyncPoolSize(readLockIdempotentReleaseDelay);
+                        }
+
+                        ScheduledExecutorService readLockIdempotentReleaseExecutorService = (ScheduledExecutorService)params.get("readLockIdempotentReleaseExecutorService");
+                        if (readLockIdempotentReleaseExecutorService != null) {
+                            readLockStrategy.setReadLockIdempotentReleaseExecutorService(readLockIdempotentReleaseExecutorService);
+                        }
+
+                        strategy = readLockStrategy;
+                    } else if ("idempotent-changed".equals(readLock)) {
+                        FileIdempotentChangedRepositoryReadLockStrategy readLockStrategy = new FileIdempotentChangedRepositoryReadLockStrategy();
+                        readLockRemoveOnRollback = (Boolean)params.get("readLockRemoveOnRollback");
+                        if (readLockRemoveOnRollback != null) {
+                            readLockStrategy.setRemoveOnRollback(readLockRemoveOnRollback);
+                        }
+
+                        readLockRemoveOnCommit = (Boolean)params.get("readLockRemoveOnCommit");
+                        if (readLockRemoveOnCommit != null) {
+                            readLockStrategy.setRemoveOnCommit(readLockRemoveOnCommit);
+                        }
+
+                        repo = (IdempotentRepository)params.get("readLockIdempotentRepository");
+                        if (repo != null) {
+                            readLockStrategy.setIdempotentRepository(repo);
+                        }
+
+                        minLength = (Long)params.get("readLockMinLength");
+                        if (minLength != null) {
+                            readLockStrategy.setMinLength(minLength);
+                        }
+
+                        Long minAge = (Long)params.get("readLockMinAge");
+                        if (null != minAge) {
+                            readLockStrategy.setMinAge(minAge);
+                        }
+
+                        readLockIdempotentReleaseDelay = (Integer)params.get("readLockIdempotentReleaseDelay");
+                        if (readLockIdempotentReleaseDelay != null) {
+                            readLockStrategy.setReadLockIdempotentReleaseDelay(readLockIdempotentReleaseDelay);
+                        }
+
+                        Boolean readLockIdempotentReleaseAsync = (Boolean)params.get("readLockIdempotentReleaseAsync");
+                        if (readLockIdempotentReleaseAsync != null) {
+                            readLockStrategy.setReadLockIdempotentReleaseAsync(readLockIdempotentReleaseAsync);
+                        }
+
+                        Integer readLockIdempotentReleaseAsyncPoolSize = (Integer)params.get("readLockIdempotentReleaseAsyncPoolSize");
+                        if (readLockIdempotentReleaseAsyncPoolSize != null) {
+                            readLockStrategy.setReadLockIdempotentReleaseAsyncPoolSize(readLockIdempotentReleaseAsyncPoolSize);
+                        }
+
+                        ScheduledExecutorService readLockIdempotentReleaseExecutorService = (ScheduledExecutorService)params.get("readLockIdempotentReleaseExecutorService");
+                        if (readLockIdempotentReleaseExecutorService != null) {
+                            readLockStrategy.setReadLockIdempotentReleaseExecutorService(readLockIdempotentReleaseExecutorService);
+                        }
+
+                        strategy = readLockStrategy;
+                    } else if ("idempotent-rename".equals(readLock)) {
+                        FileIdempotentRenameRepositoryReadLockStrategy readLockStrategy = new FileIdempotentRenameRepositoryReadLockStrategy();
+                        readLockRemoveOnRollback = (Boolean)params.get("readLockRemoveOnRollback");
+                        if (readLockRemoveOnRollback != null) {
+                            readLockStrategy.setRemoveOnRollback(readLockRemoveOnRollback);
+                        }
+
+                        readLockRemoveOnCommit = (Boolean)params.get("readLockRemoveOnCommit");
+                        if (readLockRemoveOnCommit != null) {
+                            readLockStrategy.setRemoveOnCommit(readLockRemoveOnCommit);
+                        }
+
+                        repo = (IdempotentRepository)params.get("readLockIdempotentRepository");
+                        if (repo != null) {
+                            readLockStrategy.setIdempotentRepository(repo);
+                        }
+
+                        strategy = readLockStrategy;
+                    }
+                }
+
+                if (strategy != null) {
+                    Long timeout = (Long)params.get("readLockTimeout");
+                    if (timeout != null) {
+                        ((GenericFileExclusiveReadLockStrategy)strategy).setTimeout(timeout);
+                    }
+
+                    minLength = (Long)params.get("readLockCheckInterval");
+                    if (minLength != null) {
+                        ((GenericFileExclusiveReadLockStrategy)strategy).setCheckInterval(minLength);
+                    }
+
+                    LoggingLevel readLockLoggingLevel = (LoggingLevel)params.get("readLockLoggingLevel");
+                    if (readLockLoggingLevel != null) {
+                        ((GenericFileExclusiveReadLockStrategy)strategy).setReadLockLoggingLevel(readLockLoggingLevel);
+                    }
+
+                    Boolean readLockMarkerFile = (Boolean)params.get("readLockMarkerFile");
+                    if (readLockMarkerFile != null) {
+                        ((GenericFileExclusiveReadLockStrategy)strategy).setMarkerFiler(readLockMarkerFile);
+                    }
+
+                    Boolean readLockDeleteOrphanLockFiles = (Boolean)params.get("readLockDeleteOrphanLockFiles");
+                    if (readLockDeleteOrphanLockFiles != null) {
+                        ((GenericFileExclusiveReadLockStrategy)strategy).setDeleteOrphanLockFiles(readLockDeleteOrphanLockFiles);
+                    }
+                }
+            }
+
+            return (GenericFileExclusiveReadLockStrategy)strategy;
+        }
+    }
+}

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbOperations.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbOperations.java
@@ -48,6 +48,11 @@ public class SmbOperations implements GenericFileOperations<SmbFile>, SmbShareFa
     }
 
     @Override
+    public GenericFile<SmbFile> newGenericFile() {
+        return new GenericFile<>();
+    }
+
+    @Override
     public void setEndpoint(GenericFileEndpoint<SmbFile> genericFileEndpoint) {
         this.endpoint = genericFileEndpoint;
     }

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbProducer.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbProducer.java
@@ -21,12 +21,9 @@ import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.component.file.GenericFileOperations;
 import org.apache.camel.component.file.GenericFileProducer;
-import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.ConcurrentHashMap;
 
 public class SmbProducer extends GenericFileProducer<SmbFile> {
 
@@ -34,16 +31,6 @@ public class SmbProducer extends GenericFileProducer<SmbFile> {
 
     protected SmbProducer(GenericFileEndpoint<SmbFile> endpoint, GenericFileOperations<SmbFile> operations) {
         super(endpoint, operations);
-    }
-
-    @Override
-    public Exchange createExchange() {
-        Exchange exchange = super.createExchange();
-        if (exchange.getProperties() == null && DefaultExchange.class.isAssignableFrom(exchange.getClass())){
-            DefaultExchange def = (DefaultExchange) exchange;
-            def.setProperties(new ConcurrentHashMap<>());
-        }
-        return exchange;
     }
 
     @Override

--- a/src/main/java/com/github/jborza/camel/component/smbj/SmbProducer.java
+++ b/src/main/java/com/github/jborza/camel/component/smbj/SmbProducer.java
@@ -21,12 +21,29 @@ import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileOperationFailedException;
 import org.apache.camel.component.file.GenericFileOperations;
 import org.apache.camel.component.file.GenericFileProducer;
+import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.util.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SmbProducer extends GenericFileProducer<SmbFile> {
 
+    private Logger log = LoggerFactory.getLogger(this.getClass());
+
     protected SmbProducer(GenericFileEndpoint<SmbFile> endpoint, GenericFileOperations<SmbFile> operations) {
         super(endpoint, operations);
+    }
+
+    @Override
+    public Exchange createExchange() {
+        Exchange exchange = super.createExchange();
+        if (exchange.getProperties() == null && DefaultExchange.class.isAssignableFrom(exchange.getClass())){
+            DefaultExchange def = (DefaultExchange) exchange;
+            def.setProperties(new ConcurrentHashMap<>());
+        }
+        return exchange;
     }
 
     @Override

--- a/src/test/groovy/com/github/jborza/camel/component/smbj/SmbOperationsSpec.groovy
+++ b/src/test/groovy/com/github/jborza/camel/component/smbj/SmbOperationsSpec.groovy
@@ -21,8 +21,8 @@ import org.apache.camel.component.file.FileComponent
 import org.apache.camel.component.file.GenericFile
 import org.apache.camel.component.file.GenericFileOperationFailedException
 import org.apache.camel.impl.DefaultCamelContext
-import org.apache.camel.impl.DefaultExchange
-import org.apache.camel.impl.DefaultMessage
+import org.apache.camel.support.DefaultExchange
+import org.apache.camel.support.DefaultMessage
 import org.apache.commons.io.IOUtils
 import spock.lang.Specification
 


### PR DESCRIPTION
This is update of the camel-smbj to comform with Camel 3 API 
- working and fixed Spock test issues
- added possibility to provide password as parameter (so that you can use RAW())
- synced readme with code